### PR TITLE
Updates to step.yml for compatibility and sanity check in inspect_ipa.rb

### DIFF
--- a/inspect_ipa.rb
+++ b/inspect_ipa.rb
@@ -44,7 +44,12 @@ save_env "IPA_VERSION", @app.version
 save_env "IPA_SHORT_VERSION", @app.short_version
 save_env "IPA_CREATION_DATE", @app.creation_date.to_i
 save_env "IPA_EXPIRATION_DATE", @app.expiration_date.to_i
-save_env "IPA_PROVISION_DEVICES", @app.provision_devices.join(", ")
+
+unless @app.provision_devices
+  save_env "IPA_PROVISION_DEVICES", ""
+else
+  save_env "IPA_PROVISION_DEVICES", @app.provision_devices.join(", ")
+end
 
 icons = [512, 256, 120, 60, 40]
 icons.each do |size|

--- a/step.yml
+++ b/step.yml
@@ -12,7 +12,7 @@ host_os_tags:
 type_tags:
   - environment
   - ipa
-requires_admin_user: false
+is_requires_admin_user: false
 
 inputs:
   - title: |

--- a/step.yml
+++ b/step.yml
@@ -2,6 +2,17 @@ name: IPA Inspector
 description: |
   Inspects the contents of an IPA and saves it's values as environment variables.
 
+website: https://github.com/samcassatt/steps-ipa-inspector
+source:
+  git: https://github.com/samcassatt/steps-ipa-inspector.git
+
+host_os_tags:
+  - osx-10.9
+  - osx-10.10
+type_tags:
+  - environment
+  - ipa
+requires_admin_user: false
 
 inputs:
   - title: |


### PR DESCRIPTION
I modified 2 things:
1. The current platform at bitrise.io does not support the existing format of step.yml. Some metainformation was added for compatibility.
2. nill app.provision_devices would cause a failure in inspect_ipa.rb. A check was added for this.

This has been tested to work in bitrise.
